### PR TITLE
Include <functional>

### DIFF
--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -40,6 +40,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <functional>
 
 
 namespace tsl {


### PR DESCRIPTION
Required for `std::equal_to`: http://en.cppreference.com/w/cpp/utility/functional/equal_to

(it wouldn't work for me on macOS)