### PR TITLE
Allow to use heterogeneous types for the hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ struct equal_to_str {
 int main() {
     using namespace std::literals;    
     
-    // Use std::equal_to<> which will automatically deduce and forward the paramaters
+    // Use std::equal_to<> which will automatically deduce and forward the parameters
     tsl::hopscotch_map<std::string, int, hash_str, std::equal_to<>> map = 
                                     {{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}};
     
@@ -163,7 +163,7 @@ int main() {
     
 
     
-    // Use a custome KeyEqual which has an is_transparent member type
+    // Use a custom KeyEqual which has an is_transparent member type
     tsl::hopscotch_map<std::string, int, hash_str, equal_to_str> map2;
     map2["e"] = 5;
                                                 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ All methods are not documented yet, but they replicate the behaviour of the ones
 
 ### Example
 ```c++
+#include <cstdint>
 #include <iostream>
+#include <string>
 #include "hopscotch_map.h"
 
 int main() {
@@ -96,6 +98,76 @@ int main() {
     for(const auto& key : set) {
         std::cout << "set: " << key << std::endl;
     }
+}
+```
+
+#### Heterogeneous lookup
+
+Heterogeneous overloads allow the usage of other types than `Key` for lookup and erase operations as long as the used types are hashable and comparable to `Key`.
+
+To activate the heterogeneous overloads in `tsl::hopscotch_map/set`, the qualified-id `KeyEqual::is_transparent` must be valid. It works the same way as for [`std::map::find`](http://en.cppreference.com/w/cpp/container/map/find). You can either use [`std::equal_to<>`](http://en.cppreference.com/w/cpp/utility/functional/equal_to_void) or define your own function object.
+
+Both `KeyEqual` and `Hash` will need to be able to deal with the different types.
+
+```c++
+#include <functional>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include "hopscotch_map.h"
+
+struct hash_str {
+    std::size_t operator()(const std::string& s) const {
+        return std::hash<std::string>{}(s);
+    }
+
+    std::size_t operator()(const std::string_view& s) const {
+        return std::hash<std::string_view>{}(s);
+    }
+};
+
+struct equal_to_str {
+    using is_transparent = void;
+    
+    template<typename Str1, typename Str2>
+    bool operator()(const Str1& s1, const Str2& s2) const {
+        static_assert((std::is_same<Str1, std::string>::value || 
+                       std::is_same<Str1, std::string_view>::value) && 
+                      (std::is_same<Str2, std::string>::value || 
+                       std::is_same<Str2, std::string_view>::value), 
+                      "Need a string or string_view.");
+        
+        return s1 == s2;
+    }
+};
+
+
+
+int main() {
+    using namespace std::literals;    
+    
+    // Use std::equal_to<> which will automatically deduce and forward the paramaters
+    tsl::hopscotch_map<std::string, int, hash_str, std::equal_to<>> map = 
+                                    {{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}};
+    
+
+    std::cout << "map: " << map.at(std::string_view("c")) << std::endl;
+
+    auto it = map.find("a"sv);
+    if(it != map.end()) {
+        std::cout << "map: " << it->first << " " << it->second << std::endl;
+    }
+    
+    map.erase("c"sv);
+    
+
+    
+    // Use a custome KeyEqual which has an is_transparent member type
+    tsl::hopscotch_map<std::string, int, hash_str, equal_to_str> map2;
+    map2["e"] = 5;
+                                                
+    std::cout << "map2: " << map2.at("e"sv) << std::endl;
 }
 ```
 

--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -57,6 +57,23 @@
 namespace tsl {
 
 namespace detail {
+    
+    
+    
+template<typename T>
+struct make_void {
+    using type = void;
+};
+
+template <typename T, typename = void>
+struct has_is_transparent : std::false_type {
+};
+
+template <typename T>
+struct has_is_transparent<T, typename make_void<typename T::is_transparent>::type> : std::true_type {
+};
+        
+    
 /**
  * Common class used by hopscotch_map and hopscotch_set.
  * 
@@ -111,6 +128,7 @@ private:
     public:
         using type = std::uint64_t;
     };
+    
     
 private:
     static const size_t NB_RESERVED_BITS_IN_NEIGHBORHOOD = 2; 
@@ -606,6 +624,7 @@ public:
     iterator erase(iterator pos) {
         return erase(const_iterator(pos));
     }
+    
     iterator erase(const_iterator pos) {
         const std::size_t ibucket_for_hash = bucket_for_hash(m_hash(pos.key()));
         
@@ -645,8 +664,8 @@ public:
         return to_delete;
     }
     
-    template<typename TransparentKey = key_type>
-    size_type erase(const TransparentKey& key) {
+    template<class K>
+    size_type erase(const K& key) {
         const std::size_t ibucket_for_hash = bucket_for_hash(m_hash(key));
         
         auto it_find = find_in_buckets(key, m_buckets.begin() + ibucket_for_hash);
@@ -689,8 +708,8 @@ public:
     /*
      * Lookup
      */    
-    template<typename TransparentKey = Key>
-    size_type count(const TransparentKey& key) const {
+    template<class K>
+    size_type count(const K& key) const {
         if(find(key) == end()) {
             return 0;
         }
@@ -699,28 +718,28 @@ public:
         }
     }
     
-    template<typename TransparentKey = Key>
-    iterator find(const TransparentKey& key) {
+    template<class K>
+    iterator find(const K& key) {
         const std::size_t ibucket_for_hash =  bucket_for_hash(m_hash(key));
         
         return find_internal(key, m_buckets.begin() + ibucket_for_hash);
     }
     
-    template<typename TransparentKey = Key>
-    const_iterator find(const TransparentKey& key) const {
+    template<class K>
+    const_iterator find(const K& key) const {
         const std::size_t ibucket_for_hash =  bucket_for_hash(m_hash(key));
         
         return find_internal(key, m_buckets.begin() + ibucket_for_hash);
     }
     
-    template<typename TransparentKey = Key>
-    std::pair<iterator, iterator> equal_range(const TransparentKey& key) {
+    template<class K>
+    std::pair<iterator, iterator> equal_range(const K& key) {
         iterator it = find(key);
         return std::make_pair(it, it);
     }
     
-    template<typename TransparentKey = Key>
-    std::pair<const_iterator, const_iterator> equal_range(const TransparentKey& key) const {
+    template<class K>
+    std::pair<const_iterator, const_iterator> equal_range(const K& key) const {
         const_iterator it = find(key);
         return std::make_pair(it, it);
     }
@@ -789,8 +808,8 @@ public:
      *
      * Return null if no value for key (TODO use std::optional when available).
      */
-    template<typename U = ValueSelect, typename std::enable_if<!std::is_same<U, void>::value>::type* = nullptr, typename TransparentKey = Key>
-    const typename U::value_type* find_value(const TransparentKey& key) const {
+    template<class K, class U = ValueSelect, typename std::enable_if<!std::is_same<U, void>::value>::type* = nullptr>
+    const typename U::value_type* find_value(const K& key) const {
         const std::size_t ibucket_for_hash = bucket_for_hash(m_hash(key));
         
         auto it_find = find_in_buckets(key, m_buckets.begin() + ibucket_for_hash);
@@ -1104,8 +1123,8 @@ private:
         return begin;
     }
     
-    template<typename TransparentKey = Key>
-    iterator find_internal(const TransparentKey& key, iterator_buckets it_bucket) {
+    template<class K>
+    iterator find_internal(const K& key, iterator_buckets it_bucket) {
         auto it = find_in_buckets(key, it_bucket);
         if(it != m_buckets.cend()) {
             return iterator(it, m_buckets.end(), m_overflow_elements.begin());
@@ -1122,8 +1141,8 @@ private:
                                         }));
     }
     
-    template<typename TransparentKey = Key>
-    const_iterator find_internal(const TransparentKey& key, const_iterator_buckets it_bucket) const {
+    template<class K>
+    const_iterator find_internal(const K& key, const_iterator_buckets it_bucket) const {
         auto it = find_in_buckets(key, it_bucket);
         if(it != m_buckets.cend()) {
             return const_iterator(it, m_buckets.cend(), m_overflow_elements.cbegin());
@@ -1141,15 +1160,15 @@ private:
                                             }));        
     }
     
-    template<typename TransparentKey = Key>
-    iterator_buckets find_in_buckets(const TransparentKey& key, iterator_buckets it_bucket) {
+    template<class K>
+    iterator_buckets find_in_buckets(const K& key, iterator_buckets it_bucket) {   
         auto it_find = static_cast<const hopscotch_hash*>(this)->find_in_buckets(key, it_bucket); 
         return m_buckets.begin() + std::distance(m_buckets.cbegin(), it_find);
     }
 
     
-    template<typename TransparentKey = Key>
-    const_iterator_buckets find_in_buckets(const TransparentKey& key, const_iterator_buckets it_bucket) const {
+    template<class K>
+    const_iterator_buckets find_in_buckets(const K& key, const_iterator_buckets it_bucket) const {      
         // TODO Try to optimize the function. 
         // I tried to use ffs and  __builtin_ffs functions but I could not reduce the time the function
         // takes with -march=native
@@ -1452,32 +1471,33 @@ public:
         return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
     }
 
+    
+    
     iterator erase(iterator pos) { return m_ht.erase(pos); }
     iterator erase(const_iterator pos) { return m_ht.erase(pos); }
     iterator erase(const_iterator first, const_iterator last) { return m_ht.erase(first, last); }
-    template<typename TransparentKey = key_type>
-    size_type erase(const TransparentKey& key) { return m_ht.erase(key); }
+    size_type erase(const key_type& key) { return m_ht.erase(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type erase(const K& key) { return m_ht.erase(key); }
+    
+    
     
     void swap(hopscotch_map& other) { other.swap(*this); }
     
     /*
      * Lookup
      */
-    template<typename TransparentKey = Key>
-    T& at(const TransparentKey& key) {
-        return const_cast<T&>(static_cast<const hopscotch_map*>(this)->at(key));
-    }
+    T& at(const Key& key) { return at_internal(key); }
+    const T& at(const Key& key) const { return at_internal(key); }
     
-    template<typename TransparentKey = Key>
-    const T& at(const TransparentKey& key) const {
-        const T* value = m_ht.find_value(key);
-        if(value == nullptr) {
-            throw std::out_of_range("Couldn't find key.");
-        }
-        else {
-            return *value;
-        }
-    }
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr> 
+    T& at(const K& key) { return at_internal(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>     
+    const T& at(const K& key) const { return at_internal(key); }
+    
+    
     
     T& operator[](const Key& key) {
         T* value = const_cast<T*>(m_ht.find_value(key));
@@ -1489,18 +1509,34 @@ public:
         }
     }    
     
-    template<typename TransparentKey = Key>
-    size_type count(const TransparentKey& key) const { return m_ht.count(key); }
     
-    template<typename TransparentKey = Key>
-    iterator find(const TransparentKey& key) { return m_ht.find(key); }
-    template<typename TransparentKey = Key>
-    const_iterator find(const TransparentKey& key) const { return m_ht.find(key); }
     
-    template<typename TransparentKey = Key>
-    std::pair<iterator, iterator> equal_range(const TransparentKey& key) { return m_ht.equal_range(key); }
-    template<typename TransparentKey = Key>
-    std::pair<const_iterator, const_iterator> equal_range(const TransparentKey& key) const { return m_ht.equal_range(key); }
+    size_type count(const Key& key) const { return m_ht.count(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>     
+    size_type count(const K& key) const { return m_ht.count(key); }
+    
+    
+    
+    iterator find(const Key& key) { return m_ht.find(key); }
+    const_iterator find(const Key& key) const { return m_ht.find(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr> 
+    iterator find(const K& key) { return m_ht.find(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr> 
+    const_iterator find(const K& key) const { return m_ht.find(key); }
+    
+    
+    
+    std::pair<iterator, iterator> equal_range(const Key& key) { return m_ht.equal_range(key); }
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const { return m_ht.equal_range(key); }
+
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>     
+    std::pair<iterator, iterator> equal_range(const K& key) { return m_ht.equal_range(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>     
+    std::pair<const_iterator, const_iterator> equal_range(const K& key) const { return m_ht.equal_range(key); }
     
     /*
      * Bucket interface 
@@ -1539,6 +1575,23 @@ public:
      * A high value will result in a more aggressive rehash policy but may speed-up inserts.
      */
     void max_probes_for_empty_bucket(std::size_t max_probes) { m_ht.max_probes_for_empty_bucket(max_probes); }
+    
+private:
+    template<class K>
+    T& at_internal(const K& key) {
+        return const_cast<T&>(static_cast<const hopscotch_map*>(this)->at(key));
+    }
+    
+    template<class K>
+    const T& at_internal(const K& key) const {
+        const T* value = m_ht.find_value(key);
+        if(value == nullptr) {
+            throw std::out_of_range("Couldn't find key.");
+        }
+        else {
+            return *value;
+        }
+    }    
     
 private:
     ht m_ht;
@@ -1647,7 +1700,7 @@ public:
     using const_reference = typename ht::const_reference;
     using pointer = typename ht::pointer;
     using const_pointer = typename ht::const_pointer;
-    using iterator = typename ht::const_iterator;
+    using iterator = typename ht::iterator;
     using const_iterator = typename ht::const_iterator;
 
     
@@ -1781,9 +1834,17 @@ public:
     template<class... Args>
     std::pair<iterator,bool> emplace(Args&&... args) { return m_ht.emplace(std::forward<Args>(args)...); }
 
+    
+    
+    iterator erase(iterator pos) { return m_ht.erase(pos); }
     iterator erase(const_iterator pos) { return m_ht.erase(pos); }
     iterator erase(const_iterator first, const_iterator last) { return m_ht.erase(first, last); }
     size_type erase(const key_type& key) { return m_ht.erase(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type erase(const K& key) { return m_ht.erase(key); }
+    
+    
     
     void swap(hopscotch_set& other) { other.swap(*this); }
     
@@ -1792,11 +1853,32 @@ public:
      */
     size_type count(const Key& key) const { return m_ht.count(key); }
     
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>
+    size_type count(const K& key) const { return m_ht.count(key); }
+    
+    
+    
+    
     iterator find(const Key& key) { return m_ht.find(key); }
     const_iterator find(const Key& key) const { return m_ht.find(key); }
     
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>
+    iterator find(const K& key) { return m_ht.find(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>
+    const_iterator find(const K& key) const { return m_ht.find(key); }
+    
+    
+    
     std::pair<iterator, iterator> equal_range(const Key& key) { return m_ht.equal_range(key); }
     std::pair<const_iterator, const_iterator> equal_range(const Key& key) const { return m_ht.equal_range(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>     
+    std::pair<iterator, iterator> equal_range(const K& key) { return m_ht.equal_range(key); }
+    
+    template<class K, class KE = KeyEqual, typename std::enable_if<tsl::detail::has_is_transparent<KE>::value>::type* = nullptr>     
+    std::pair<const_iterator, const_iterator> equal_range(const K& key) const { return m_ht.equal_range(key); }
+    
     
     /*
      * Bucket interface 

--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -642,7 +642,8 @@ public:
         return to_delete;
     }
     
-    size_type erase(const key_type& key) {
+    template<typename TransparentKey = key_type>
+    size_type erase(const TransparentKey& key) {
         const std::size_t ibucket_for_hash = bucket_for_hash(m_hash(key));
         
         auto it_find = find_in_buckets(key, m_buckets.begin() + ibucket_for_hash);
@@ -785,8 +786,8 @@ public:
      *
      * Return null if no value for key (TODO use std::optional when available).
      */
-    template<class U = ValueSelect, typename std::enable_if<!std::is_same<U, void>::value>::type* = nullptr>
-    const typename U::value_type* find_value(const Key& key) const {
+    template<typename U = ValueSelect, typename std::enable_if<!std::is_same<U, void>::value>::type* = nullptr, typename TransparentKey = Key>
+    const typename U::value_type* find_value(const TransparentKey& key) const {
         const std::size_t ibucket_for_hash = bucket_for_hash(m_hash(key));
         
         auto it_find = find_in_buckets(key, m_buckets.begin() + ibucket_for_hash);
@@ -1100,7 +1101,8 @@ private:
         return begin;
     }
     
-    iterator find_internal(const Key& key, iterator_buckets it_bucket) {
+    template<typename TransparentKey = Key>
+    iterator find_internal(const TransparentKey& key, iterator_buckets it_bucket) {
         auto it = find_in_buckets(key, it_bucket);
         if(it != m_buckets.cend()) {
             return iterator(it, m_buckets.end(), m_overflow_elements.begin());
@@ -1117,7 +1119,8 @@ private:
                                         }));
     }
     
-    const_iterator find_internal(const Key& key, const_iterator_buckets it_bucket) const {
+    template<typename TransparentKey = Key>
+    const_iterator find_internal(const TransparentKey& key, const_iterator_buckets it_bucket) const {
         auto it = find_in_buckets(key, it_bucket);
         if(it != m_buckets.cend()) {
             return const_iterator(it, m_buckets.cend(), m_overflow_elements.cbegin());
@@ -1135,13 +1138,15 @@ private:
                                             }));        
     }
     
-    iterator_buckets find_in_buckets(const Key& key, iterator_buckets it_bucket) {   
+    template<typename TransparentKey = Key>
+    iterator_buckets find_in_buckets(const TransparentKey& key, iterator_buckets it_bucket) {
         auto it_find = static_cast<const hopscotch_hash*>(this)->find_in_buckets(key, it_bucket); 
         return m_buckets.begin() + std::distance(m_buckets.cbegin(), it_find);
     }
 
     
-    const_iterator_buckets find_in_buckets(const Key& key, const_iterator_buckets it_bucket) const {      
+    template<typename TransparentKey = Key>
+    const_iterator_buckets find_in_buckets(const TransparentKey& key, const_iterator_buckets it_bucket) const {
         // TODO Try to optimize the function. 
         // I tried to use ffs and  __builtin_ffs functions but I could not reduce the time the function
         // takes with -march=native
@@ -1446,7 +1451,8 @@ public:
 
     iterator erase(const_iterator pos) { return m_ht.erase(pos); }
     iterator erase(const_iterator first, const_iterator last) { return m_ht.erase(first, last); }
-    size_type erase(const key_type& key) { return m_ht.erase(key); }
+    template<typename TransparentKey = key_type>
+    size_type erase(const TransparentKey& key) { return m_ht.erase(key); }
     
     void swap(hopscotch_map& other) { other.swap(*this); }
     

--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -685,7 +685,8 @@ public:
     /*
      * Lookup
      */    
-    size_type count(const Key& key) const {
+    template<typename TransparentKey = Key>
+    size_type count(const TransparentKey& key) const {
         if(find(key) == end()) {
             return 0;
         }
@@ -694,24 +695,28 @@ public:
         }
     }
     
-    iterator find(const Key& key) {
+    template<typename TransparentKey = Key>
+    iterator find(const TransparentKey& key) {
         const std::size_t ibucket_for_hash =  bucket_for_hash(m_hash(key));
         
         return find_internal(key, m_buckets.begin() + ibucket_for_hash);
     }
     
-    const_iterator find(const Key& key) const {
+    template<typename TransparentKey = Key>
+    const_iterator find(const TransparentKey& key) const {
         const std::size_t ibucket_for_hash =  bucket_for_hash(m_hash(key));
         
         return find_internal(key, m_buckets.begin() + ibucket_for_hash);
     }
     
-    std::pair<iterator, iterator> equal_range(const Key& key) {
+    template<typename TransparentKey = Key>
+    std::pair<iterator, iterator> equal_range(const TransparentKey& key) {
         iterator it = find(key);
         return std::make_pair(it, it);
     }
     
-    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const {
+    template<typename TransparentKey = Key>
+    std::pair<const_iterator, const_iterator> equal_range(const TransparentKey& key) const {
         const_iterator it = find(key);
         return std::make_pair(it, it);
     }
@@ -1448,11 +1453,13 @@ public:
     /*
      * Lookup
      */
-    T& at(const Key& key) {
+    template<typename TransparentKey = Key>
+    T& at(const TransparentKey& key) {
         return const_cast<T&>(static_cast<const hopscotch_map*>(this)->at(key));
     }
     
-    const T& at(const Key& key) const {
+    template<typename TransparentKey = Key>
+    const T& at(const TransparentKey& key) const {
         const T* value = m_ht.find_value(key);
         if(value == nullptr) {
             throw std::out_of_range("Couldn't find key.");
@@ -1462,7 +1469,8 @@ public:
         }
     }
     
-    T& operator[](const Key& key) {
+    template<typename TransparentKey = Key>
+    T& operator[](const TransparentKey& key) {
         T* value = const_cast<T*>(m_ht.find_value(key));
         if(value == nullptr) {
             return insert(std::make_pair(key, T())).first.value();
@@ -1472,13 +1480,18 @@ public:
         }
     }    
     
-    size_type count(const Key& key) const { return m_ht.count(key); }
+    template<typename TransparentKey = Key>
+    size_type count(const TransparentKey& key) const { return m_ht.count(key); }
     
-    iterator find(const Key& key) { return m_ht.find(key); }
-    const_iterator find(const Key& key) const { return m_ht.find(key); }
+    template<typename TransparentKey = Key>
+    iterator find(const TransparentKey& key) { return m_ht.find(key); }
+    template<typename TransparentKey = Key>
+    const_iterator find(const TransparentKey& key) const { return m_ht.find(key); }
     
-    std::pair<iterator, iterator> equal_range(const Key& key) { return m_ht.equal_range(key); }
-    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const { return m_ht.equal_range(key); }
+    template<typename TransparentKey = Key>
+    std::pair<iterator, iterator> equal_range(const TransparentKey& key) { return m_ht.equal_range(key); }
+    template<typename TransparentKey = Key>
+    std::pair<const_iterator, const_iterator> equal_range(const TransparentKey& key) const { return m_ht.equal_range(key); }
     
     /*
      * Bucket interface 

--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -1475,8 +1475,7 @@ public:
         }
     }
     
-    template<typename TransparentKey = Key>
-    T& operator[](const TransparentKey& key) {
+    T& operator[](const Key& key) {
         T* value = const_cast<T*>(m_ht.find_value(key));
         if(value == nullptr) {
             return insert(std::make_pair(key, T())).first.value();

--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -603,6 +603,9 @@ public:
         return try_emplace_internal(std::move(k), std::forward<Args>(args)...);
     }
     
+    iterator erase(iterator pos) {
+        return erase(const_iterator(pos));
+    }
     iterator erase(const_iterator pos) {
         const std::size_t ibucket_for_hash = bucket_for_hash(m_hash(pos.key()));
         
@@ -1449,6 +1452,7 @@ public:
         return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
     }
 
+    iterator erase(iterator pos) { return m_ht.erase(pos); }
     iterator erase(const_iterator pos) { return m_ht.erase(pos); }
     iterator erase(const_iterator first, const_iterator last) { return m_ht.erase(first, last); }
     template<typename TransparentKey = key_type>


### PR DESCRIPTION
For instance, given `hopscotch_map<std::string, int, string_hash>`, this allows to do a `find(string_view)`
given a hash functor and equal functor with the correct overloads, such as :

``` c++
struct string_hash
{
  std::size_t operator()(const std::string& s) const
  {
    return std::hash<std::string>{}(s);
  }

  std::size_t operator()(std::string_view s) const
  {
    return std::hash<std::string_view>{}(s);
  }
};

struct string_equal
{
  bool operator()(const std::string& s, const std::string& s2) const
  {
    return s == s2;
  }
  bool operator()(std::string_view s, const std::string& s2) const
  {
    return s == s2;
  }
  bool operator()(const std::string& s, std::string_view s2) const
  {
    return s == s2;
  }
};

```