### PR TITLE
Reduce identifiers length to avoid VS 'decorated name length exceeded' (C4503) warning

### DIFF
--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -73,6 +73,39 @@ struct has_is_transparent : std::false_type {
 template <typename T>
 struct has_is_transparent<T, typename make_void<typename T::is_transparent>::type> : std::true_type {
 };
+
+
+/*
+ * smallest_type_for_min_bits::type returns the smallest type that can fit MinBits.
+ */
+static const size_t SMALLEST_TYPE_MAX_BITS_SUPPORTED = 64;
+template<unsigned int MinBits, typename Enable = void>
+class smallest_type_for_min_bits {
+};
+
+template<unsigned int MinBits>
+class smallest_type_for_min_bits<MinBits, typename std::enable_if<(MinBits > 0) && (MinBits <= 8)>::type> {
+public:
+    using type = std::uint8_t;
+};
+
+template<unsigned int MinBits>
+class smallest_type_for_min_bits<MinBits, typename std::enable_if<(MinBits > 8) && (MinBits <= 16)>::type> {
+public:
+    using type = std::uint16_t;
+};
+
+template<unsigned int MinBits>
+class smallest_type_for_min_bits<MinBits, typename std::enable_if<(MinBits > 16) && (MinBits <= 32)>::type> {
+public:
+    using type = std::uint32_t;
+};
+
+template<unsigned int MinBits>
+class smallest_type_for_min_bits<MinBits, typename std::enable_if<(MinBits > 32) && (MinBits <= 64)>::type> {
+public:
+    using type = std::uint64_t;
+};
         
     
 /**
@@ -96,40 +129,6 @@ template<class ValueType,
 class hopscotch_hash {
 private:    
     using Key = typename KeySelect::key_type;
-    
-private:
-    /*
-     * smallest_type_for_min_bits::type returns the smallest type that can fit MinBits.
-     */
-    static const size_t SMALLEST_TYPE_MAX_BITS_SUPPORTED = 64;
-    template<unsigned int MinBits, typename Enable = void>
-    class smallest_type_for_min_bits {
-    };
-
-    template<unsigned int MinBits>
-    class smallest_type_for_min_bits<MinBits, typename std::enable_if<(MinBits > 0) && (MinBits <= 8)>::type> {
-    public:
-        using type = std::uint8_t;
-    };
-
-    template<unsigned int MinBits>
-    class smallest_type_for_min_bits<MinBits, typename std::enable_if<(MinBits > 8) && (MinBits <= 16)>::type> {
-    public:
-        using type = std::uint16_t;
-    };
-
-    template<unsigned int MinBits>
-    class smallest_type_for_min_bits<MinBits, typename std::enable_if<(MinBits > 16) && (MinBits <= 32)>::type> {
-    public:
-        using type = std::uint32_t;
-    };
-
-    template<unsigned int MinBits>
-    class smallest_type_for_min_bits<MinBits, typename std::enable_if<(MinBits > 32) && (MinBits <= 64)>::type> {
-    public:
-        using type = std::uint64_t;
-    };
-    
     
 private:
     static const size_t NB_RESERVED_BITS_IN_NEIGHBORHOOD = 2; 

--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -130,6 +130,12 @@ class hopscotch_bucket {
 private:
     static const size_t MAX_NEIGHBORHOOD_SIZE = SMALLEST_TYPE_MAX_BITS_SUPPORTED - NB_RESERVED_BITS_IN_NEIGHBORHOOD; 
     
+    /*
+     * NeighborhoodSize need to be between 0 and MAX_NEIGHBORHOOD_SIZE.
+     */
+    static_assert(NeighborhoodSize > 0, "NeighborhoodSize should be > 0.");
+    static_assert(NeighborhoodSize <= MAX_NEIGHBORHOOD_SIZE, "NeighborhoodSize should be <= 62.");
+    
 public:
     using value_type = ValueType;
     using neighborhood_bitmap = 
@@ -338,24 +344,11 @@ template<class ValueType,
          unsigned int NeighborhoodSize,
          class GrowthFactor>
 class hopscotch_hash {
-private:    
-    using Key = typename KeySelect::key_type;
-    
-    
-    /*
-     * NeighborhoodSize need to be between 0 and MAX_NEIGHBORHOOD_SIZE.
-     */
-    static_assert(NeighborhoodSize > 0, "NeighborhoodSize should be > 0.");
-    static_assert(NeighborhoodSize <= 62, "NeighborhoodSize should be <= 62.");
-    
-    using hopscotch_bucket = tsl::detail_hopscotch_hash::hopscotch_bucket<ValueType, NeighborhoodSize>;
-    using neighborhood_bitmap = typename hopscotch_bucket::neighborhood_bitmap;
-
 public:
     template<bool is_const>
     class hopscotch_iterator;
     
-    using key_type = Key;
+    using key_type = typename KeySelect::key_type;
     using value_type = ValueType;
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
@@ -370,6 +363,10 @@ public:
     using const_iterator = hopscotch_iterator<true>;
     
 private:
+    using hopscotch_bucket = tsl::detail_hopscotch_hash::hopscotch_bucket<ValueType, NeighborhoodSize>;
+    using neighborhood_bitmap = typename hopscotch_bucket::neighborhood_bitmap;
+    
+    
     using buckets_allocator = typename std::allocator_traits<allocator_type>::template rebind_alloc<hopscotch_bucket>;
     using overflow_elements_allocator = 
                                 typename std::allocator_traits<allocator_type>::template rebind_alloc<value_type>;  


### PR DESCRIPTION
Move `hopscotch_bucket` and `smallest_type_for_min_bits` out of the `hopscotch_hash` class into the detail namespace. It reduces the identifiers length so we can avoid the C4503 warning mentioned in issue #9.