### PR TITLE
Allow the hash to be stored alongside the neighborhood bitmap.

### DIFF
--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -524,8 +524,10 @@ public:
                                             m_nb_elements(0),
                                             m_hash(hash), m_key_equal(equal)
     {
+        const size_type min_bucket_count = MIN_BUCKETS_SIZE;
+        
         bucket_count = USE_POWER_OF_TWO_MOD?round_up_to_power_of_two(bucket_count):bucket_count;
-        bucket_count = std::max(bucket_count, MIN_BUCKETS_SIZE);
+        bucket_count = std::max(bucket_count, min_bucket_count);
         
         if(bucket_count > max_bucket_count()) {
             throw std::length_error("The map exceeds its maxmimum size.");

--- a/src/hopscotch_map.h
+++ b/src/hopscotch_map.h
@@ -1399,7 +1399,7 @@ private:
         neighborhood_bitmap neighborhood_infos = it_bucket->get_neighborhood_infos();
         while(neighborhood_infos != 0) {
             if((neighborhood_infos & 1) == 1) {
-                if(it_bucket->bucket_hash_equal(hash) && m_key_equal(KeySelect()(it_bucket->get_value()), key)) {
+                if((!StoreHash || it_bucket->bucket_hash_equal(hash)) && m_key_equal(KeySelect()(it_bucket->get_value()), key)) {
                     return it_bucket;
                 }
             }


### PR DESCRIPTION
A new template parameter StoreHash is added. 

If present the hash of an inserted value will be stored alongside the neighborhood bitmap for faster rehash and faster read in some cases. 

When StoreHash is true, the neighborhood size is limited to 30. Instead of using 64 bits (with two reserved bits) for the neighborhood, 32 bits will be used for the hash and 32 bits for the neighborood.