### PR TITLE
Add a more flexible growth policy

### DIFF
--- a/tests/hopscotch_map_tests.cpp
+++ b/tests/hopscotch_map_tests.cpp
@@ -10,8 +10,6 @@
 using test_types = boost::mpl::list<tsl::hopscotch_map<int64_t, int64_t>, 
                                     tsl::hopscotch_map<int64_t, int64_t, std::hash<int64_t>, std::equal_to<int64_t>, 
                                         std::allocator<std::pair<int64_t, int64_t>>, 6>, 
-                                    tsl::hopscotch_map<int64_t, int64_t, std::hash<int64_t>, std::equal_to<int64_t>, 
-                                        std::allocator<std::pair<int64_t, int64_t>>, 6, std::ratio<4,3>>, 
                                     // Test with hash having a lot of collisions
                                     tsl::hopscotch_map<int64_t, int64_t, mod_hash<9>>,
                                     tsl::hopscotch_map<int64_t, int64_t, mod_hash<9>, std::equal_to<int64_t>, 


### PR DESCRIPTION
Remove GrowthFactor to use a GrowthPolicy template class parameter instead which offers more flexibility.