### PR TITLE
Bug correction (#31), set a moved hash map in a valid state so that it can still be used even after a move

### DIFF
--- a/src/hopscotch_hash.h
+++ b/src/hopscotch_hash.h
@@ -205,7 +205,6 @@ public:
     }
     
 private:
-    static const std::size_t MIN_BUCKETS_SIZE = 2;
     static constexpr double REHASH_SIZE_MULTIPLICATION_FACTOR = 1.0*GrowthFactor::num/GrowthFactor::den;
     static const std::size_t MAX_BUCKET_COUNT = 
             std::size_t(double(

--- a/tests/policy_tests.cpp
+++ b/tests/policy_tests.cpp
@@ -18,10 +18,17 @@ BOOST_AUTO_TEST_CASE(test_power_of_two_policy) {
     std::size_t bucket_count = 0;
     tsl::power_of_two_growth_policy policy(bucket_count);
     
+    BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+    BOOST_CHECK_EQUAL(bucket_count, 0);
+    
+    
     try {
         while(true) {
             bucket_count = policy.next_bucket_count();
             policy = tsl::power_of_two_growth_policy(bucket_count);
+            
+            BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+            BOOST_CHECK(bucket_count > 0);
         }
     }
     catch(const std::length_error& ) {
@@ -66,10 +73,17 @@ BOOST_AUTO_TEST_CASE(test_prime_policy) {
     std::size_t bucket_count = 0;
     tsl::prime_growth_policy policy(bucket_count);
     
+    BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+    BOOST_CHECK_EQUAL(bucket_count, 0);
+    
+    
     try {
         while(true) {
             bucket_count = policy.next_bucket_count();
             policy = tsl::prime_growth_policy(bucket_count);
+            
+            BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+            BOOST_CHECK(bucket_count > 0);
         }
     }
     catch(const std::length_error& ) {
@@ -114,10 +128,16 @@ BOOST_AUTO_TEST_CASE(test_mod_policy) {
     std::size_t bucket_count = 0;
     tsl::mod_growth_policy<> policy(bucket_count);
     
+    BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+    BOOST_CHECK_EQUAL(bucket_count, 0);
+    
     try {
         while(true) {
             bucket_count = policy.next_bucket_count();
             policy = tsl::mod_growth_policy<>(bucket_count);
+            
+            BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+            BOOST_CHECK(bucket_count > 0);
         }
     }
     catch(const std::length_error& ) {


### PR DESCRIPTION
Correct issue #31 , a moved `tsl::hopscotch_map` or `tsl::hopscotch_set` can now still be used after a move. Previously the map ended up in a invalid state after a move but the standard mandates that a moved object should be in a valid (but unspecified) state so that it can still be used after a move.

The following code will now work:
```c++
tsl::hopscotch_set<int> set = {0, 1, 2, 3, 4};
tsl::hopscotch_set<int> set2 = std::move(set);
    
set.erase(0);
set.find(0);
set.insert(0);
```