### PR TITLE
Add Conan support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,22 @@ matrix:
       compiler: clang
       env:
         - CBUILD_TYPE="Release"
-      
+
     - os: linux
       compiler: gcc
       env:
         - CBUILD_TYPE="Release"
-      
+
     - os: osx
       compiler: clang
       env:
         - CBUILD_TYPE="Release"
-      
+
     - os: osx
       compiler: gcc
       env:
         - CBUILD_TYPE="Release"
-      
+
     - os: linux
       compiler: clang
       dist: xenial
@@ -31,12 +31,27 @@ matrix:
         - CBUILD_TYPE="Release"
         - TYPE="sanitize"
         - CXXFLAGS="-fsanitize=address,undefined"
-      
+
     - os: linux
       compiler: gcc
       env:
         - TYPE="coverage"
         - CXXFLAGS="--coverage"
+
+    - os: linux
+        dist: xenial
+        sudo: true
+        language: python
+        python: "3.7"
+        services:
+          - docker
+        env:
+          - CONAN_GCC_VERSIONS=8
+          - CONAN_DOCKER_IMAGE=conanio/gcc8
+        install:
+          - pip install conan_package_tools
+        script:
+          - python conan/build.py
 
 addons:
   apt:
@@ -54,4 +69,3 @@ script:
 
 after_success:
   - if [[ "$TYPE" == "coverage" ]]; then lcov -c -b ../../include/ -d . -o coverage.info --no-external && bash <(curl -s https://codecov.io/bash) -f coverage.info; fi
-

--- a/conan/build.py
+++ b/conan/build.py
@@ -1,0 +1,18 @@
+import os
+
+from conan.packager import ConanMultiPackager
+
+
+if __name__ == "__main__":
+    username = "tessil"
+    channel = "stable"
+    upload_remote = "https://api.bintray.com/conan/tessil/tsl" if os.getenv("TRAVIS_TAG") else None
+    test_folder = os.path.join("conan", "test_package")
+
+    builder = ConanMultiPackager(username=username,
+                                 channel=channel,
+                                 upload=upload_remote,
+                                 test_folder=test_folder)
+    builder.add_common_builds()
+    builder.builds = [builder.builds[0]]
+    builder.run()

--- a/conan/test_package/CMakeLists.txt
+++ b/conan/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} CONAN_PKG::tsl-hopscotch-map)

--- a/conan/test_package/conanfile.py
+++ b/conan/test_package/conanfile.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+import os
+from conans import ConanFile, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        test_package = os.path.join("bin", "test_package")
+        self.run(test_package, run_environment=True)

--- a/conan/test_package/test_package.cpp
+++ b/conan/test_package/test_package.cpp
@@ -1,0 +1,64 @@
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <tsl/hopscotch_map.h>
+#include <tsl/hopscotch_set.h>
+
+int main() {
+    tsl::hopscotch_map<std::string, int> map = {{"a", 1}, {"b", 2}};
+    map["c"] = 3;
+    map["d"] = 4;
+
+    map.insert({"e", 5});
+    map.erase("b");
+
+    for(auto it = map.begin(); it != map.end(); ++it) {
+        //it->second += 2; // Not valid.
+        it.value() += 2;
+    }
+
+    // {d, 6} {a, 3} {e, 7} {c, 5}
+    for(const auto& key_value : map) {
+        std::cout << "{" << key_value.first << ", " << key_value.second << "}" << std::endl;
+    }
+
+
+    if(map.find("a") != map.end()) {
+        std::cout << "Found \"a\"." << std::endl;
+    }
+
+    const std::size_t precalculated_hash = std::hash<std::string>()("a");
+    // If we already know the hash beforehand, we can pass it in parameter to speed-up lookups.
+    if(map.find("a", precalculated_hash) != map.end()) {
+        std::cout << "Found \"a\" with hash " << precalculated_hash << "." << std::endl;
+    }
+
+
+    /*
+     * Calculating the hash and comparing two std::string may be slow. 
+     * We can store the hash of each std::string in the hash map to make 
+     * the inserts and lookups faster by setting StoreHash to true.
+     */ 
+    tsl::hopscotch_map<std::string, int, std::hash<std::string>,
+                       std::equal_to<std::string>,
+                       std::allocator<std::pair<std::string, int>>,
+                       30, true> map2;
+
+    map2["a"] = 1;
+    map2["b"] = 2;
+
+    // {a, 1} {b, 2}
+    for(const auto& key_value : map2) {
+        std::cout << "{" << key_value.first << ", " << key_value.second << "}" << std::endl;
+    }
+
+
+    tsl::hopscotch_set<int> set;
+    set.insert({1, 9, 0});
+    set.insert({2, -1, 9});
+
+    // {0} {1} {2} {9} {-1}
+    for(const auto& key : set) {
+        std::cout << "{" << key << "}" << std::endl;
+    }
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,31 @@
+import re
+from conans import ConanFile, CMake, tools
+
+
+def get_version():
+    """ Extract version of library from CMakeLists.txt file """
+    try:
+        content = tools.load("CMakeLists.txt")
+        version = re.search(r"project\(tsl-hopscotch-map VERSION (.*)\)", content).group(1)
+        return version.strip()
+    except Exception:
+        return None
+
+
+class TslHopscotchMapConan(ConanFile):
+    name = "tsl-hopscotch-map"
+    url = "https://github.com/Tessil/hopscotch-map"
+    version = get_version()
+    license = "MIT"
+    description="C++ implementation of a fast hash map and hash set using hopscotch hashing."
+    exports_sources = "*"
+    exports = "LICENSE"
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", keep_path=False, ignore_case=True)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.install()
+
+    def package_id(self):
+        self.info.header_only()


### PR DESCRIPTION
Hi!

I was reviewing your inclusion request for Conan Center and having a conanfile in the source repository is much better.

I have created an updated conanfile with the following enhancements:
- Sources are exported instead of cloning the repo (no need to clone sources as you already have them).
- Include library license in the binary packages.
- Extract library version from CMakelists.txt

I have also included a ``conan`` folder with some additional things.

- ``test_pacakge`` folder: Includes the example of you readme with conanfile.py consumer of your Conan package library. This is useful to make sure the package is correctly created.

- Conan Package Tools build script ``build.py``: This scripts generates your Conan package and gets it uploaded to your Bintray.com account (**IMPORTANT**: You would need to create a new **hidden** environment variable in Travis CI called "CONAN_PASSWORD" with you Bintray API token).

  I have included a check so only new tags on Travis are actually uploaded (new package on every new release). I have also added a new entry in the Travis matrix for this (independent from any other CI config you already had).

Hope it makes sense and do not hesitate to make any question.
Thanks!