### PR TITLE
Work with allocators passed through by std::pmr

### DIFF
--- a/include/tsl/bhopscotch_map.h
+++ b/include/tsl/bhopscotch_map.h
@@ -135,6 +135,9 @@ class bhopscotch_map {
                  const Allocator& alloc)
       : bhopscotch_map(bucket_count, hash, KeyEqual(), alloc) {}
 
+  bhopscotch_map(const bhopscotch_map& other, const Allocator& alloc)
+      : m_ht(other.m_ht, alloc) {}
+
   explicit bhopscotch_map(const Allocator& alloc)
       : bhopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {}
 

--- a/include/tsl/bhopscotch_set.h
+++ b/include/tsl/bhopscotch_set.h
@@ -115,6 +115,9 @@ class bhopscotch_set {
   explicit bhopscotch_set(const Allocator& alloc)
       : bhopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {}
 
+  bhopscotch_set(const bhopscotch_set& other, const Allocator& alloc)
+      : m_ht(other.m_ht, alloc) {}
+
   template <class InputIt>
   bhopscotch_set(InputIt first, InputIt last,
                  size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,

--- a/include/tsl/hopscotch_hash.h
+++ b/include/tsl/hopscotch_hash.h
@@ -671,7 +671,7 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
                   "move constructible.");
   }
 
-  hopscotch_hash(const hopscotch_hash& other) : hopscotch_hash(other, get_allocator()) {}
+  hopscotch_hash(const hopscotch_hash& other) : hopscotch_hash(other, other.get_allocator()) {}
 
   hopscotch_hash(const hopscotch_hash& other, const Allocator& alloc)
       : Hash(other),

--- a/include/tsl/hopscotch_hash.h
+++ b/include/tsl/hopscotch_hash.h
@@ -671,7 +671,8 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
                   "move constructible.");
   }
 
-  hopscotch_hash(const hopscotch_hash& other) : hopscotch_hash(other, other.get_allocator()) {}
+  hopscotch_hash(const hopscotch_hash& other)
+      : hopscotch_hash(other, other.get_allocator()) {}
 
   hopscotch_hash(const hopscotch_hash& other, const Allocator& alloc)
       : Hash(other),

--- a/include/tsl/hopscotch_hash.h
+++ b/include/tsl/hopscotch_hash.h
@@ -671,11 +671,13 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
                   "move constructible.");
   }
 
-  hopscotch_hash(const hopscotch_hash& other)
+  hopscotch_hash(const hopscotch_hash& other) : hopscotch_hash(other, get_allocator()) {}
+
+  hopscotch_hash(const hopscotch_hash& other, const Allocator& alloc)
       : Hash(other),
         KeyEqual(other),
         GrowthPolicy(other),
-        m_buckets_data(other.m_buckets_data),
+        m_buckets_data(other.m_buckets_data, alloc),
         m_overflow_elements(other.m_overflow_elements),
         m_buckets(m_buckets_data.empty() ? static_empty_bucket_ptr()
                                          : m_buckets_data.data()),

--- a/include/tsl/hopscotch_map.h
+++ b/include/tsl/hopscotch_map.h
@@ -152,7 +152,8 @@ class hopscotch_map {
   explicit hopscotch_map(const Allocator& alloc)
       : hopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {}
 
-  explicit hopscotch_map(const hopscotch_map& other, const Allocator& alloc) : m_ht(other.m_ht, alloc) {}
+  hopscotch_map(const hopscotch_map& other, const Allocator& alloc)
+      : m_ht(other.m_ht, alloc) {}
 
   template <class InputIt>
   hopscotch_map(InputIt first, InputIt last,

--- a/include/tsl/hopscotch_map.h
+++ b/include/tsl/hopscotch_map.h
@@ -152,6 +152,8 @@ class hopscotch_map {
   explicit hopscotch_map(const Allocator& alloc)
       : hopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {}
 
+  explicit hopscotch_map(const hopscotch_map& other, const Allocator& alloc) : m_ht(other.m_ht, alloc) {}
+
   template <class InputIt>
   hopscotch_map(InputIt first, InputIt last,
                 size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,

--- a/include/tsl/hopscotch_set.h
+++ b/include/tsl/hopscotch_set.h
@@ -131,6 +131,9 @@ class hopscotch_set {
                 const Allocator& alloc)
       : hopscotch_set(bucket_count, hash, KeyEqual(), alloc) {}
 
+  hopscotch_set(const hopscotch_set& other, const Allocator& alloc)
+      : m_ht(other.m_ht, alloc) {}
+
   explicit hopscotch_set(const Allocator& alloc)
       : hopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {}
 


### PR DESCRIPTION
The following program reproduces the issue.

    using HopscotchAllocator = std::pmr::polymorphic_allocator<std::pair<int,int>>;
    using HopscotchMap =
       tsl::hopscotch_map<int, int, std::hash<int>, std::equal_to<int>, HopscotchAllocator>;
    std::pmr::vector<HopscotchMap> v(std::pmr::get_default_resource());
    v.resize(5);
    for (auto& m : v) { m.reserve(1000); }

Producing the error:

memory_resource:257:13: error: no matching function for call to ‘tsl::hopscotch_map<int, int, std::hash<int>, std::equal_to<int>, std::pmr::polymorphic_allocator<std::pair<int, int> > >::hopscotch_map(tsl::hopscotch_map<int, int, std::hash<int>, std::equal_to<int>, std::pmr::polymorphic_allocator<std::pair<int, int> > >, std::pmr::polymorphic_allocator<tsl::hopscotch_ map<int, int, std::hash<int>, std::equal_to<int>, std::pmr::polymorphic_allocator<std::pair<int, int> > > >&)’
  257 |             ::new(__p) _Tp1(std::forward<_Args>(__args)..., *this);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

std::pmr::vector.resize() wants a copy constructor that takes an allocator. Define a simple one and the program compiles with no issues.