### PR TITLE
Add additional heterogeneous overloads.

### DIFF
--- a/include/tsl/bhopscotch_map.h
+++ b/include/tsl/bhopscotch_map.h
@@ -258,6 +258,15 @@ class bhopscotch_map {
     return m_ht.insert_or_assign(std::move(k), std::forward<M>(obj));
   }
 
+  // P2363R5
+  template <
+      class K, class M, class KE = KeyEqual, class CP = Compare,
+      typename std::enable_if<has_is_transparent<KE>::value &&
+                              has_is_transparent<CP>::value>::type* = nullptr>
+  std::pair<iterator, bool> insert_or_assign(K&& k, M&& obj) {
+    return m_ht.insert_or_assign(std::forward<K>(k), std::forward<M>(obj));
+  }
+
   template <class M>
   iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj) {
     return m_ht.insert_or_assign(hint, k, std::forward<M>(obj));
@@ -266,6 +275,16 @@ class bhopscotch_map {
   template <class M>
   iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj) {
     return m_ht.insert_or_assign(hint, std::move(k), std::forward<M>(obj));
+  }
+
+  // P2363R5
+  template <
+      class K, class M, class KE = KeyEqual, class CP = Compare,
+      typename std::enable_if<has_is_transparent<KE>::value &&
+                              has_is_transparent<CP>::value>::type* = nullptr>
+  iterator insert_or_assign(const_iterator hint, K&& k, M&& obj) {
+    return m_ht.insert_or_assign(hint, std::forward<K>(k),
+                                 std::forward<M>(obj));
   }
 
   /**
@@ -302,6 +321,17 @@ class bhopscotch_map {
     return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
   }
 
+  // P2363R5
+  template <
+      class K, class... Args, class KE = KeyEqual, class CP = Compare,
+      typename std::enable_if<
+          has_is_transparent<KE>::value && has_is_transparent<CP>::value &&
+          !std::is_convertible_v<K&&, const_iterator> &&
+          !std::is_convertible_v<K&&, iterator>>::type* = nullptr>
+  std::pair<iterator, bool> try_emplace(K&& k, Args&&... args) {
+    return m_ht.try_emplace(std::forward<K>(k), std::forward<Args>(args)...);
+  }
+
   template <class... Args>
   iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args) {
     return m_ht.try_emplace(hint, k, std::forward<Args>(args)...);
@@ -310,6 +340,18 @@ class bhopscotch_map {
   template <class... Args>
   iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args) {
     return m_ht.try_emplace(hint, std::move(k), std::forward<Args>(args)...);
+  }
+
+  // P2363R5
+  template <
+      class K, class... Args, class KE = KeyEqual, class CP = Compare,
+      typename std::enable_if<
+          has_is_transparent<KE>::value && has_is_transparent<CP>::value &&
+          !std::is_convertible_v<K&&, const_iterator> &&
+          !std::is_convertible_v<K&&, iterator>>::type* = nullptr>
+  iterator try_emplace(const_iterator hint, K&& k, Args&&... args) {
+    return m_ht.try_emplace(hint, std::forward<K>(k),
+                            std::forward<Args>(args)...);
   }
 
   iterator erase(iterator pos) { return m_ht.erase(pos); }
@@ -433,6 +475,20 @@ class bhopscotch_map {
 
   T& operator[](const Key& key) { return m_ht[key]; }
   T& operator[](Key&& key) { return m_ht[std::move(key)]; }
+
+  // P2363R5
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent and Compare::is_transparent exist. If so, K must
+   * be hashable and comparable to Key.
+   */
+  template <
+      class K, class KE = KeyEqual, class CP = Compare,
+      typename std::enable_if<has_is_transparent<KE>::value &&
+                              has_is_transparent<CP>::value>::type* = nullptr>
+  T& operator[](K&& key) {
+    return m_ht[std::forward<K>(key)];
+  }
 
   size_type count(const Key& key) const { return m_ht.count(key); }
 

--- a/include/tsl/bhopscotch_map.h
+++ b/include/tsl/bhopscotch_map.h
@@ -338,6 +338,7 @@ class bhopscotch_map {
       class K, class... Args, class KE = KeyEqual, class CP = Compare,
       typename std::enable_if<
           has_is_transparent<KE>::value && has_is_transparent<CP>::value &&
+          !std::is_convertible<K&&, iterator>::value &&
           !std::is_convertible<K&&, const_iterator>::value>::type* = nullptr>
   std::pair<iterator, bool> try_emplace(K&& k, Args&&... args) {
     return m_ht.try_emplace(std::forward<K>(k), std::forward<Args>(args)...);
@@ -362,6 +363,7 @@ class bhopscotch_map {
       class K, class... Args, class KE = KeyEqual, class CP = Compare,
       typename std::enable_if<
           has_is_transparent<KE>::value && has_is_transparent<CP>::value &&
+          !std::is_convertible<K&&, iterator>::value &&
           !std::is_convertible<K&&, const_iterator>::value>::type* = nullptr>
   iterator try_emplace(const_iterator hint, K&& k, Args&&... args) {
     return m_ht.try_emplace(hint, std::forward<K>(k),

--- a/include/tsl/bhopscotch_map.h
+++ b/include/tsl/bhopscotch_map.h
@@ -258,7 +258,11 @@ class bhopscotch_map {
     return m_ht.insert_or_assign(std::move(k), std::forward<M>(obj));
   }
 
-  // P2363R5
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent and Compare::is_transparent exist. If so, K must
+   * be hashable and comparable to Key.
+   */
   template <
       class K, class M, class KE = KeyEqual, class CP = Compare,
       typename std::enable_if<has_is_transparent<KE>::value &&
@@ -277,7 +281,11 @@ class bhopscotch_map {
     return m_ht.insert_or_assign(hint, std::move(k), std::forward<M>(obj));
   }
 
-  // P2363R5
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent and Compare::is_transparent exist. If so, K must
+   * be hashable and comparable to Key.
+   */
   template <
       class K, class M, class KE = KeyEqual, class CP = Compare,
       typename std::enable_if<has_is_transparent<KE>::value &&
@@ -321,13 +329,16 @@ class bhopscotch_map {
     return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
   }
 
-  // P2363R5
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent and Compare::is_transparent exist. If so, K must
+   * be hashable and comparable to Key.
+   */
   template <
       class K, class... Args, class KE = KeyEqual, class CP = Compare,
       typename std::enable_if<
           has_is_transparent<KE>::value && has_is_transparent<CP>::value &&
-          !std::is_convertible_v<K&&, const_iterator> &&
-          !std::is_convertible_v<K&&, iterator>>::type* = nullptr>
+          !std::is_convertible<K&&, const_iterator>::value>::type* = nullptr>
   std::pair<iterator, bool> try_emplace(K&& k, Args&&... args) {
     return m_ht.try_emplace(std::forward<K>(k), std::forward<Args>(args)...);
   }
@@ -342,13 +353,16 @@ class bhopscotch_map {
     return m_ht.try_emplace(hint, std::move(k), std::forward<Args>(args)...);
   }
 
-  // P2363R5
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent and Compare::is_transparent exist. If so, K must
+   * be hashable and comparable to Key.
+   */
   template <
       class K, class... Args, class KE = KeyEqual, class CP = Compare,
       typename std::enable_if<
           has_is_transparent<KE>::value && has_is_transparent<CP>::value &&
-          !std::is_convertible_v<K&&, const_iterator> &&
-          !std::is_convertible_v<K&&, iterator>>::type* = nullptr>
+          !std::is_convertible<K&&, const_iterator>::value>::type* = nullptr>
   iterator try_emplace(const_iterator hint, K&& k, Args&&... args) {
     return m_ht.try_emplace(hint, std::forward<K>(k),
                             std::forward<Args>(args)...);
@@ -476,7 +490,6 @@ class bhopscotch_map {
   T& operator[](const Key& key) { return m_ht[key]; }
   T& operator[](Key&& key) { return m_ht[std::move(key)]; }
 
-  // P2363R5
   /**
    * This overload only participates in the overload resolution if the typedef
    * KeyEqual::is_transparent and Compare::is_transparent exist. If so, K must

--- a/include/tsl/bhopscotch_set.h
+++ b/include/tsl/bhopscotch_set.h
@@ -70,6 +70,12 @@ class bhopscotch_set {
     const key_type& operator()(const Key& key) const { return key; }
 
     key_type& operator()(Key& key) { return key; }
+
+    template <class K, typename std::enable_if<std::is_constructible<
+                           key_type, const K&>::value>::type* = nullptr>
+    const K& operator()(const K& key) const {
+      return key;
+    }
   };
 
   using overflow_container_type = std::set<Key, Compare, Allocator>;
@@ -195,11 +201,36 @@ class bhopscotch_set {
     return m_ht.insert(std::move(value));
   }
 
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent and Compare::is_transparent exist. If so, K must
+   * be hashable and comparable to Key.
+   */
+  template <
+      class K, class KE = KeyEqual, class CP = Compare,
+      typename std::enable_if<has_is_transparent<KE>::value &&
+                              has_is_transparent<CP>::value>::type* = nullptr>
+  std::pair<iterator, bool> insert(K&& key) {
+    return m_ht.insert(std::forward<K>(key));
+  }
+
   iterator insert(const_iterator hint, const value_type& value) {
     return m_ht.insert(hint, value);
   }
   iterator insert(const_iterator hint, value_type&& value) {
     return m_ht.insert(hint, std::move(value));
+  }
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent and Compare::is_transparent exist. If so, K must
+   * be hashable and comparable to Key.
+   */
+  template <
+      class K, class KE = KeyEqual, class CP = Compare,
+      typename std::enable_if<has_is_transparent<KE>::value &&
+                              has_is_transparent<CP>::value>::type* = nullptr>
+  iterator insert(const_iterator hint, K&& value) {
+    return m_ht.insert(hint, std::forward<K>(value));
   }
 
   template <class InputIt>

--- a/include/tsl/hopscotch_hash.h
+++ b/include/tsl/hopscotch_hash.h
@@ -805,7 +805,7 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
   template <class P, typename std::enable_if<std::is_constructible<
                          value_type, P&&>::value>::type* = nullptr>
   std::pair<iterator, bool> insert(P&& value) {
-    return insert_impl(value_type(std::forward<P>(value)));
+    return insert_impl(std::forward<P>(value));
   }
 
   std::pair<iterator, bool> insert(value_type&& value) {
@@ -824,7 +824,12 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
   template <class P, typename std::enable_if<std::is_constructible<
                          value_type, P&&>::value>::type* = nullptr>
   iterator insert(const_iterator hint, P&& value) {
-    return emplace_hint(hint, std::forward<P>(value));
+    if (hint != cend() &&
+        compare_keys(KeySelect()(*hint), KeySelect()(value))) {
+      return mutable_iterator(hint);
+    }
+
+    return insert(std::forward<P>(value)).first;
   }
 
   iterator insert(const_iterator hint, value_type&& value) {

--- a/include/tsl/hopscotch_hash.h
+++ b/include/tsl/hopscotch_hash.h
@@ -870,6 +870,11 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
     return insert_or_assign_impl(std::move(k), std::forward<M>(obj));
   }
 
+  template <class K, class M>
+  std::pair<iterator, bool> insert_or_assign(K&& k, M&& obj) {
+    return insert_or_assign_impl(std::forward<K>(k), std::forward<M>(obj));
+  }
+
   template <class M>
   iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj) {
     if (hint != cend() && compare_keys(KeySelect()(*hint), k)) {
@@ -894,6 +899,18 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
     return insert_or_assign(std::move(k), std::forward<M>(obj)).first;
   }
 
+  template <class K, class M>
+  iterator insert_or_assign(const_iterator hint, K&& k, M&& obj) {
+    if (hint != cend() && compare_keys(KeySelect()(*hint), k)) {
+      auto it = mutable_iterator(hint);
+      it.value() = std::forward<M>(obj);
+
+      return it;
+    }
+
+    return insert_or_assign(std::forward<K>(k), std::forward<M>(obj)).first;
+  }
+
   template <class... Args>
   std::pair<iterator, bool> emplace(Args&&... args) {
     return insert(value_type(std::forward<Args>(args)...));
@@ -914,6 +931,11 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
     return try_emplace_impl(std::move(k), std::forward<Args>(args)...);
   }
 
+  template <class K, class... Args>
+  std::pair<iterator, bool> try_emplace(K&& k, Args&&... args) {
+    return try_emplace_impl(std::forward<K>(k), std::forward<Args>(args)...);
+  }
+
   template <class... Args>
   iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args) {
     if (hint != cend() && compare_keys(KeySelect()(*hint), k)) {
@@ -930,6 +952,15 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
     }
 
     return try_emplace(std::move(k), std::forward<Args>(args)...).first;
+  }
+
+  template <class K, class... Args>
+  iterator try_emplace(const_iterator hint, K&& k, Args&&... args) {
+    if (hint != cend() && compare_keys(KeySelect()(*hint), k)) {
+      return mutable_iterator(hint);
+    }
+
+    return try_emplace(std::forward<K>(k), std::forward<Args>(args)...).first;
   }
 
   /**

--- a/include/tsl/hopscotch_map.h
+++ b/include/tsl/hopscotch_map.h
@@ -272,7 +272,11 @@ class hopscotch_map {
     return m_ht.insert_or_assign(std::move(k), std::forward<M>(obj));
   }
 
-  // P2363R5
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
   template <
       class K, class M, class KE = KeyEqual,
       typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
@@ -290,7 +294,11 @@ class hopscotch_map {
     return m_ht.insert_or_assign(hint, std::move(k), std::forward<M>(obj));
   }
 
-  // P2363R5
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
   template <
       class K, class M, class KE = KeyEqual,
       typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
@@ -333,12 +341,16 @@ class hopscotch_map {
     return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
   }
 
-  // P2363R5
-  template <class K, class... Args, class KE = KeyEqual,
-            typename std::enable_if<
-                has_is_transparent<KE>::value &&
-                !std::is_convertible_v<K&&, const_iterator> &&
-                !std::is_convertible_v<K&&, iterator>>::type* = nullptr>
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class... Args, class KE = KeyEqual,
+      typename std::enable_if<
+          has_is_transparent<KE>::value &&
+          !std::is_convertible<K&&, const_iterator>::value>::type* = nullptr>
   std::pair<iterator, bool> try_emplace(K&& k, Args&&... args) {
     return m_ht.try_emplace(std::forward<K>(k), std::forward<Args>(args)...);
   }
@@ -353,12 +365,16 @@ class hopscotch_map {
     return m_ht.try_emplace(hint, std::move(k), std::forward<Args>(args)...);
   }
 
-  // P2363R5
-  template <class K, class... Args, class KE = KeyEqual,
-            typename std::enable_if<
-                has_is_transparent<KE>::value &&
-                !std::is_convertible_v<K&&, const_iterator> &&
-                !std::is_convertible_v<K&&, iterator>>::type* = nullptr>
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class... Args, class KE = KeyEqual,
+      typename std::enable_if<
+          has_is_transparent<KE>::value &&
+          !std::is_convertible<K&&, const_iterator>::value>::type* = nullptr>
   iterator try_emplace(const_iterator hint, K&& k, Args&&... args) {
     return m_ht.try_emplace(hint, std::forward<K>(k),
                             std::forward<Args>(args)...);
@@ -480,7 +496,6 @@ class hopscotch_map {
   T& operator[](const Key& key) { return m_ht[key]; }
   T& operator[](Key&& key) { return m_ht[std::move(key)]; }
 
-  // P2363R5
   /**
    * This overload only participates in the overload resolution if the typedef
    * KeyEqual::is_transparent exists. If so, K must be hashable and comparable

--- a/include/tsl/hopscotch_map.h
+++ b/include/tsl/hopscotch_map.h
@@ -272,6 +272,14 @@ class hopscotch_map {
     return m_ht.insert_or_assign(std::move(k), std::forward<M>(obj));
   }
 
+  // P2363R5
+  template <
+      class K, class M, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<iterator, bool> insert_or_assign(K&& k, M&& obj) {
+    return m_ht.insert_or_assign(std::forward<K>(k), std::forward<M>(obj));
+  }
+
   template <class M>
   iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj) {
     return m_ht.insert_or_assign(hint, k, std::forward<M>(obj));
@@ -280,6 +288,15 @@ class hopscotch_map {
   template <class M>
   iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj) {
     return m_ht.insert_or_assign(hint, std::move(k), std::forward<M>(obj));
+  }
+
+  // P2363R5
+  template <
+      class K, class M, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  iterator insert_or_assign(const_iterator hint, K&& k, M&& obj) {
+    return m_ht.insert_or_assign(hint, std::forward<K>(k),
+                                 std::forward<M>(obj));
   }
 
   /**
@@ -316,6 +333,16 @@ class hopscotch_map {
     return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
   }
 
+  // P2363R5
+  template <class K, class... Args, class KE = KeyEqual,
+            typename std::enable_if<
+                has_is_transparent<KE>::value &&
+                !std::is_convertible_v<K&&, const_iterator> &&
+                !std::is_convertible_v<K&&, iterator>>::type* = nullptr>
+  std::pair<iterator, bool> try_emplace(K&& k, Args&&... args) {
+    return m_ht.try_emplace(std::forward<K>(k), std::forward<Args>(args)...);
+  }
+
   template <class... Args>
   iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args) {
     return m_ht.try_emplace(hint, k, std::forward<Args>(args)...);
@@ -324,6 +351,17 @@ class hopscotch_map {
   template <class... Args>
   iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args) {
     return m_ht.try_emplace(hint, std::move(k), std::forward<Args>(args)...);
+  }
+
+  // P2363R5
+  template <class K, class... Args, class KE = KeyEqual,
+            typename std::enable_if<
+                has_is_transparent<KE>::value &&
+                !std::is_convertible_v<K&&, const_iterator> &&
+                !std::is_convertible_v<K&&, iterator>>::type* = nullptr>
+  iterator try_emplace(const_iterator hint, K&& k, Args&&... args) {
+    return m_ht.try_emplace(hint, std::forward<K>(k),
+                            std::forward<Args>(args)...);
   }
 
   iterator erase(iterator pos) { return m_ht.erase(pos); }
@@ -441,6 +479,19 @@ class hopscotch_map {
 
   T& operator[](const Key& key) { return m_ht[key]; }
   T& operator[](Key&& key) { return m_ht[std::move(key)]; }
+
+  // P2363R5
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  T& operator[](K&& key) {
+    return m_ht[std::forward<K>(key)];
+  }
 
   size_type count(const Key& key) const { return m_ht.count(key); }
 

--- a/include/tsl/hopscotch_map.h
+++ b/include/tsl/hopscotch_map.h
@@ -350,6 +350,7 @@ class hopscotch_map {
       class K, class... Args, class KE = KeyEqual,
       typename std::enable_if<
           has_is_transparent<KE>::value &&
+          !std::is_convertible<K&&, iterator>::value &&
           !std::is_convertible<K&&, const_iterator>::value>::type* = nullptr>
   std::pair<iterator, bool> try_emplace(K&& k, Args&&... args) {
     return m_ht.try_emplace(std::forward<K>(k), std::forward<Args>(args)...);
@@ -374,6 +375,7 @@ class hopscotch_map {
       class K, class... Args, class KE = KeyEqual,
       typename std::enable_if<
           has_is_transparent<KE>::value &&
+          !std::is_convertible<K&&, iterator>::value &&
           !std::is_convertible<K&&, const_iterator>::value>::type* = nullptr>
   iterator try_emplace(const_iterator hint, K&& k, Args&&... args) {
     return m_ht.try_emplace(hint, std::forward<K>(k),

--- a/include/tsl/hopscotch_set.h
+++ b/include/tsl/hopscotch_set.h
@@ -92,6 +92,12 @@ class hopscotch_set {
     const key_type& operator()(const Key& key) const { return key; }
 
     key_type& operator()(Key& key) { return key; }
+
+    template <class K, typename std::enable_if<std::is_constructible<
+                           key_type, const K&>::value>::type* = nullptr>
+    const K& operator()(const K& key) const {
+      return key;
+    }
   };
 
   using overflow_container_type = std::list<Key, Allocator>;
@@ -213,12 +219,34 @@ class hopscotch_set {
   std::pair<iterator, bool> insert(value_type&& value) {
     return m_ht.insert(std::move(value));
   }
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<iterator, bool> insert(K&& value) {
+    return m_ht.insert(std::forward<K>(value));
+  }
 
   iterator insert(const_iterator hint, const value_type& value) {
     return m_ht.insert(hint, value);
   }
   iterator insert(const_iterator hint, value_type&& value) {
     return m_ht.insert(hint, std::move(value));
+  }
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  iterator insert(const_iterator hint, K&& value) {
+    return m_ht.insert(hint, std::forward<K>(value));
   }
 
   template <class InputIt>

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -205,6 +205,33 @@ class copy_only_test {
   std::string m_value;
 };
 
+class heterogeneous_test {
+ public:
+  struct eq : std::equal_to<int> {
+    using is_transparent = void;
+  };
+  struct less : std::less<int> {
+    using is_transparent = void;
+  };
+  explicit heterogeneous_test(int i) : m_value(i) {
+    heterogeneous_test::constructed_add(1);
+  }
+
+  operator int() const { return m_value; }
+
+  static int constructed_add(int i) {
+    static int inst = 0;
+    inst += i;
+    return inst;
+  }
+  static int constructed() { return constructed_add(0); }
+
+ private:
+  int m_value;
+};
+static_assert(std::is_constructible<heterogeneous_test, int>::value,
+              "should be constructible from int");
+
 namespace std {
 template <>
 struct hash<self_reference_member_test> {
@@ -226,6 +253,8 @@ struct hash<copy_only_test> {
     return std::hash<std::string>()(val.value());
   }
 };
+template <>
+struct hash<heterogeneous_test> : std::hash<int> {};
 }  // namespace std
 
 class utils {


### PR DESCRIPTION
* Add heterogeneous overloads for try_emplace, insert_or_assign, and operator[] to {b}hopscotch_map and hopscotch_hash.

* Similar overloads were added to the standard associative containers with C++26 (see P2363R5).