### PR TITLE
Enable noexcept for special member functions

### DIFF
--- a/include/tsl/bhopscotch_map.h
+++ b/include/tsl/bhopscotch_map.h
@@ -119,7 +119,7 @@ class bhopscotch_map {
   /*
    * Constructors
    */
-  bhopscotch_map() : bhopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  bhopscotch_map() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0) : bhopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
 
   explicit bhopscotch_map(size_type bucket_count, const Hash& hash = Hash(),
                           const KeyEqual& equal = KeyEqual(),
@@ -414,7 +414,7 @@ class bhopscotch_map {
     return m_ht.erase(key, precalculated_hash);
   }
 
-  void swap(bhopscotch_map& other) { other.m_ht.swap(m_ht); }
+  void swap(bhopscotch_map& other) noexcept(noexcept(other.m_ht.swap(m_ht))) { other.m_ht.swap(m_ht); }
 
   /*
    * Lookup
@@ -785,7 +785,7 @@ class bhopscotch_map {
     return !operator==(lhs, rhs);
   }
 
-  friend void swap(bhopscotch_map& lhs, bhopscotch_map& rhs) { lhs.swap(rhs); }
+  friend void swap(bhopscotch_map& lhs, bhopscotch_map& rhs) noexcept(noexcept(lhs.swap(rhs))) { lhs.swap(rhs); }
 
  private:
   ht m_ht;

--- a/include/tsl/bhopscotch_map.h
+++ b/include/tsl/bhopscotch_map.h
@@ -119,7 +119,13 @@ class bhopscotch_map {
   /*
    * Constructors
    */
-  bhopscotch_map() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0) : bhopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  bhopscotch_map() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0 &&
+                            std::is_nothrow_default_constructible<Hash>::value &&
+                            std::is_nothrow_default_constructible<KeyEqual>::value &&
+                            std::is_nothrow_default_constructible<Allocator>::value &&
+                            (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
+                             hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
+      : bhopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
 
   explicit bhopscotch_map(size_type bucket_count, const Hash& hash = Hash(),
                           const KeyEqual& equal = KeyEqual(),

--- a/include/tsl/bhopscotch_map.h
+++ b/include/tsl/bhopscotch_map.h
@@ -119,13 +119,8 @@ class bhopscotch_map {
   /*
    * Constructors
    */
-  bhopscotch_map() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0 &&
-                            std::is_nothrow_default_constructible<Hash>::value &&
-                            std::is_nothrow_default_constructible<KeyEqual>::value &&
-                            std::is_nothrow_default_constructible<Allocator>::value &&
-                            (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
-                             hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
-      : bhopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  bhopscotch_map() noexcept(std::is_nothrow_default_constructible<ht>::value)
+      : m_ht() {}
 
   explicit bhopscotch_map(size_type bucket_count, const Hash& hash = Hash(),
                           const KeyEqual& equal = KeyEqual(),

--- a/include/tsl/bhopscotch_set.h
+++ b/include/tsl/bhopscotch_set.h
@@ -102,7 +102,7 @@ class bhopscotch_set {
   /*
    * Constructors
    */
-  bhopscotch_set() : bhopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  bhopscotch_set() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0) : bhopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
 
   explicit bhopscotch_set(size_type bucket_count, const Hash& hash = Hash(),
                           const KeyEqual& equal = KeyEqual(),
@@ -309,7 +309,7 @@ class bhopscotch_set {
     return m_ht.erase(key, precalculated_hash);
   }
 
-  void swap(bhopscotch_set& other) { other.m_ht.swap(m_ht); }
+  void swap(bhopscotch_set& other) noexcept(noexcept(other.m_ht.swap(m_ht))) { other.m_ht.swap(m_ht); }
 
   /*
    * Lookup
@@ -597,7 +597,7 @@ class bhopscotch_set {
     return !operator==(lhs, rhs);
   }
 
-  friend void swap(bhopscotch_set& lhs, bhopscotch_set& rhs) { lhs.swap(rhs); }
+  friend void swap(bhopscotch_set& lhs, bhopscotch_set& rhs) noexcept(noexcept(lhs.swap(rhs))) { lhs.swap(rhs); }
 
  private:
   ht m_ht;

--- a/include/tsl/bhopscotch_set.h
+++ b/include/tsl/bhopscotch_set.h
@@ -102,13 +102,8 @@ class bhopscotch_set {
   /*
    * Constructors
    */
-  bhopscotch_set() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0 &&
-                            std::is_nothrow_default_constructible<Hash>::value &&
-                            std::is_nothrow_default_constructible<KeyEqual>::value &&
-                            std::is_nothrow_default_constructible<Allocator>::value &&
-                            (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
-                             hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
-      : bhopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  bhopscotch_set() noexcept(std::is_nothrow_default_constructible<ht>::value)
+      : m_ht() {}
 
   explicit bhopscotch_set(size_type bucket_count, const Hash& hash = Hash(),
                           const KeyEqual& equal = KeyEqual(),

--- a/include/tsl/bhopscotch_set.h
+++ b/include/tsl/bhopscotch_set.h
@@ -102,7 +102,13 @@ class bhopscotch_set {
   /*
    * Constructors
    */
-  bhopscotch_set() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0) : bhopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  bhopscotch_set() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0 &&
+                            std::is_nothrow_default_constructible<Hash>::value &&
+                            std::is_nothrow_default_constructible<KeyEqual>::value &&
+                            std::is_nothrow_default_constructible<Allocator>::value &&
+                            (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
+                             hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
+      : bhopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
 
   explicit bhopscotch_set(size_type bucket_count, const Hash& hash = Hash(),
                           const KeyEqual& equal = KeyEqual(),

--- a/include/tsl/hopscotch_growth_policy.h
+++ b/include/tsl/hopscotch_growth_policy.h
@@ -399,6 +399,19 @@ class prime_growth_policy {
                 "The type of m_iprime is not big enough.");
 };
 
+/**
+ * SFINAE helper to detect growth policies which can be noexcept-initialized
+ * with a zero min bucket count.
+ */
+template<typename>
+struct is_noexcept_on_zero_init : std::false_type {};
+template<std::size_t GrowthFactor>
+struct is_noexcept_on_zero_init<power_of_two_growth_policy<GrowthFactor>> : std::true_type {};
+template<class GrowthFactor>
+struct is_noexcept_on_zero_init<mod_growth_policy<GrowthFactor>> : std::true_type {};
+template<>
+struct is_noexcept_on_zero_init<prime_growth_policy> : std::true_type {};
+
 }  // namespace hh
 }  // namespace tsl
 

--- a/include/tsl/hopscotch_hash.h
+++ b/include/tsl/hopscotch_hash.h
@@ -730,7 +730,7 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
     return *this;
   }
 
-  hopscotch_hash& operator=(hopscotch_hash&& other) {
+  hopscotch_hash& operator=(hopscotch_hash&& other) noexcept(noexcept(other.swap(*this))) {
     other.swap(*this);
     other.clear();
 
@@ -1035,7 +1035,11 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
     return 0;
   }
 
-  void swap(hopscotch_hash& other) {
+  void swap(hopscotch_hash& other) noexcept(std::is_nothrow_swappable<Hash>::value &&
+                                            std::is_nothrow_swappable<KeyEqual>::value &&
+                                            std::is_nothrow_swappable<GrowthPolicy>::value &&
+                                            std::is_nothrow_swappable<buckets_container_type>::value &&
+                                            std::is_nothrow_swappable<overflow_container_type>::value) {
     using std::swap;
 
     swap(static_cast<Hash&>(*this), static_cast<Hash&>(other));

--- a/include/tsl/hopscotch_hash.h
+++ b/include/tsl/hopscotch_hash.h
@@ -596,6 +596,17 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
   template <
       class OC = OverflowContainer,
       typename std::enable_if<!has_key_compare<OC>::value>::type* = nullptr>
+  hopscotch_hash() noexcept(DEFAULT_INIT_BUCKETS_SIZE == 0 &&
+                            std::is_nothrow_default_constructible<Hash>::value &&
+                            std::is_nothrow_default_constructible<KeyEqual>::value &&
+                            std::is_nothrow_default_constructible<Allocator>::value &&
+                            (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
+                             hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
+      : hopscotch_hash(DEFAULT_INIT_BUCKETS_SIZE, Hash(), KeyEqual(), Allocator(), DEFAULT_MAX_LOAD_FACTOR) {}
+
+  template <
+      class OC = OverflowContainer,
+      typename std::enable_if<!has_key_compare<OC>::value>::type* = nullptr>
   hopscotch_hash(size_type bucket_count, const Hash& hash,
                  const KeyEqual& equal, const Allocator& alloc,
                  float max_load_factor)
@@ -629,6 +640,17 @@ class hopscotch_hash : private Hash, private KeyEqual, private GrowthPolicy {
                   "value_type must be either copy constructible or nothrow "
                   "move constructible.");
   }
+
+  template <
+      class OC = OverflowContainer,
+      typename std::enable_if<has_key_compare<OC>::value>::type* = nullptr>
+  hopscotch_hash() noexcept(DEFAULT_INIT_BUCKETS_SIZE == 0 &&
+                            std::is_nothrow_default_constructible<Hash>::value &&
+                            std::is_nothrow_default_constructible<KeyEqual>::value &&
+                            std::is_nothrow_default_constructible<Allocator>::value &&
+                            (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
+                             hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
+      : hopscotch_hash(DEFAULT_INIT_BUCKETS_SIZE, Hash(), KeyEqual(), Allocator(), DEFAULT_MAX_LOAD_FACTOR, typename OC::key_compare()) {}
 
   template <
       class OC = OverflowContainer,

--- a/include/tsl/hopscotch_map.h
+++ b/include/tsl/hopscotch_map.h
@@ -135,13 +135,8 @@ class hopscotch_map {
   /*
    * Constructors
    */
-  hopscotch_map() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0 &&
-                           std::is_nothrow_default_constructible<Hash>::value &&
-                           std::is_nothrow_default_constructible<KeyEqual>::value &&
-                           std::is_nothrow_default_constructible<Allocator>::value &&
-                           (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
-                            hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
-      : hopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  hopscotch_map() noexcept(std::is_nothrow_default_constructible<ht>::value)
+      : m_ht() {}
 
   explicit hopscotch_map(size_type bucket_count, const Hash& hash = Hash(),
                          const KeyEqual& equal = KeyEqual(),

--- a/include/tsl/hopscotch_map.h
+++ b/include/tsl/hopscotch_map.h
@@ -135,7 +135,7 @@ class hopscotch_map {
   /*
    * Constructors
    */
-  hopscotch_map() : hopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  hopscotch_map() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0) : hopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
 
   explicit hopscotch_map(size_type bucket_count, const Hash& hash = Hash(),
                          const KeyEqual& equal = KeyEqual(),
@@ -424,7 +424,7 @@ class hopscotch_map {
     return m_ht.erase(key, precalculated_hash);
   }
 
-  void swap(hopscotch_map& other) { other.m_ht.swap(m_ht); }
+  void swap(hopscotch_map& other) noexcept(noexcept(other.m_ht.swap(m_ht))) { other.m_ht.swap(m_ht); }
 
   /*
    * Lookup
@@ -783,7 +783,7 @@ class hopscotch_map {
     return !operator==(lhs, rhs);
   }
 
-  friend void swap(hopscotch_map& lhs, hopscotch_map& rhs) { lhs.swap(rhs); }
+  friend void swap(hopscotch_map& lhs, hopscotch_map& rhs) noexcept(noexcept(lhs.swap(rhs))) { lhs.swap(rhs); }
 
  private:
   ht m_ht;

--- a/include/tsl/hopscotch_map.h
+++ b/include/tsl/hopscotch_map.h
@@ -135,7 +135,13 @@ class hopscotch_map {
   /*
    * Constructors
    */
-  hopscotch_map() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0) : hopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  hopscotch_map() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0 &&
+                           std::is_nothrow_default_constructible<Hash>::value &&
+                           std::is_nothrow_default_constructible<KeyEqual>::value &&
+                           std::is_nothrow_default_constructible<Allocator>::value &&
+                           (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
+                            hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
+      : hopscotch_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
 
   explicit hopscotch_map(size_type bucket_count, const Hash& hash = Hash(),
                          const KeyEqual& equal = KeyEqual(),

--- a/include/tsl/hopscotch_set.h
+++ b/include/tsl/hopscotch_set.h
@@ -123,13 +123,8 @@ class hopscotch_set {
   /*
    * Constructors
    */
-  hopscotch_set() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0 &&
-                           std::is_nothrow_default_constructible<Hash>::value &&
-                           std::is_nothrow_default_constructible<KeyEqual>::value &&
-                           std::is_nothrow_default_constructible<Allocator>::value &&
-                           (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
-                            hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
-      : hopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  hopscotch_set() noexcept(std::is_nothrow_default_constructible<ht>::value)
+      : m_ht() {}
 
   explicit hopscotch_set(size_type bucket_count, const Hash& hash = Hash(),
                          const KeyEqual& equal = KeyEqual(),

--- a/include/tsl/hopscotch_set.h
+++ b/include/tsl/hopscotch_set.h
@@ -123,7 +123,13 @@ class hopscotch_set {
   /*
    * Constructors
    */
-  hopscotch_set() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0) : hopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  hopscotch_set() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0 &&
+                           std::is_nothrow_default_constructible<Hash>::value &&
+                           std::is_nothrow_default_constructible<KeyEqual>::value &&
+                           std::is_nothrow_default_constructible<Allocator>::value &&
+                           (std::is_nothrow_constructible<GrowthPolicy, std::size_t&>::value ||
+                            hh::is_noexcept_on_zero_init<GrowthPolicy>::value))
+      : hopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
 
   explicit hopscotch_set(size_type bucket_count, const Hash& hash = Hash(),
                          const KeyEqual& equal = KeyEqual(),

--- a/include/tsl/hopscotch_set.h
+++ b/include/tsl/hopscotch_set.h
@@ -123,7 +123,7 @@ class hopscotch_set {
   /*
    * Constructors
    */
-  hopscotch_set() : hopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+  hopscotch_set() noexcept(ht::DEFAULT_INIT_BUCKETS_SIZE == 0) : hopscotch_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
 
   explicit hopscotch_set(size_type bucket_count, const Hash& hash = Hash(),
                          const KeyEqual& equal = KeyEqual(),
@@ -323,7 +323,7 @@ class hopscotch_set {
     return m_ht.erase(key, precalculated_hash);
   }
 
-  void swap(hopscotch_set& other) { other.m_ht.swap(m_ht); }
+  void swap(hopscotch_set& other) noexcept(noexcept(other.m_ht.swap(m_ht))) { other.m_ht.swap(m_ht); }
 
   /*
    * Lookup
@@ -600,7 +600,7 @@ class hopscotch_set {
     return !operator==(lhs, rhs);
   }
 
-  friend void swap(hopscotch_set& lhs, hopscotch_set& rhs) { lhs.swap(rhs); }
+  friend void swap(hopscotch_set& lhs, hopscotch_set& rhs) noexcept(noexcept(lhs.swap(rhs))) { lhs.swap(rhs); }
 
  private:
   ht m_ht;

--- a/tests/hopscotch_map_tests.cpp
+++ b/tests/hopscotch_map_tests.cpp
@@ -1510,4 +1510,11 @@ BOOST_AUTO_TEST_CASE(test_precalculated_hash) {
   BOOST_CHECK_EQUAL(map.erase(4, map.hash_function()(2)), 0);
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_noexcept, HSet, test_types) {
+  static_assert(std::is_nothrow_default_constructible<HSet>::value, "");
+  static_assert(std::is_nothrow_move_constructible<HSet>::value, "");
+  static_assert(std::is_nothrow_move_assignable<HSet>::value, "");
+  static_assert(std::is_nothrow_swappable<HSet>::value, "");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/hopscotch_set_tests.cpp
+++ b/tests/hopscotch_set_tests.cpp
@@ -163,4 +163,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_insert_transparent_hint, HSet,
   BOOST_CHECK_EQUAL(*otherIt, 2);
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_noexcept, HSet, test_types) {
+  static_assert(std::is_nothrow_default_constructible<HSet>::value, "");
+  static_assert(std::is_nothrow_move_constructible<HSet>::value, "");
+  static_assert(std::is_nothrow_move_assignable<HSet>::value, "");
+  static_assert(std::is_nothrow_swappable<HSet>::value, "");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The hopscotch_hash container already was nothrow move constructible, but was missing the conditional noexcept for the default constructor, swap, and move assignment.