### PR TITLE
avoid GCC16 maybe-uninitialized warning in growth policies

### DIFF
--- a/include/tsl/hopscotch_growth_policy.h
+++ b/include/tsl/hopscotch_growth_policy.h
@@ -129,7 +129,7 @@ class power_of_two_growth_policy {
   /**
    * Return the maximum number of buckets supported by the policy.
    */
-  std::size_t max_bucket_count() const {
+  static constexpr std::size_t max_bucket_count() {
     // Largest power of two.
     return (std::numeric_limits<std::size_t>::max() / 2) + 1;
   }
@@ -215,7 +215,7 @@ class mod_growth_policy {
     }
   }
 
-  std::size_t max_bucket_count() const { return MAX_BUCKET_COUNT; }
+  static constexpr std::size_t max_bucket_count() { return MAX_BUCKET_COUNT; }
 
   void clear() noexcept { m_mod = 1; }
 
@@ -386,7 +386,7 @@ class prime_growth_policy {
     return detail::PRIMES[m_iprime + 1];
   }
 
-  std::size_t max_bucket_count() const { return detail::PRIMES.back(); }
+  static constexpr std::size_t max_bucket_count() { return detail::PRIMES.back(); }
 
   void clear() noexcept { m_iprime = 0; }
 


### PR DESCRIPTION
Compiling with GCC16 generated the following warning:
```
hopscotch_growth_policy.h:95:51: warning: ‘<unknown>’ may be used uninitialized [-Wmaybe-uninitialized]
   95 |     if (min_bucket_count_in_out > max_bucket_count()) {
      |                                   ~~~~~~~~~~~~~~~~^~
```
While warning looks questionable, simply making max_bucket_count static avoids this warning.